### PR TITLE
clarified wildcards for current directory

### DIFF
--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -32,7 +32,7 @@ Let's go into that directory with `cd` and run the command `wc *.pdb`.
 `wc` is the "word count" command:
 it counts the number of lines, words, and characters in files.
 The `*` in `*.pdb` matches zero or more characters,
-so the shell turns `*.pdb` into a complete list of `.pdb` files:
+so the shell turns `*.pdb` into a list of `.pdb` files in the current directory:
 
 ~~~ {.bash}
 $ cd molecules


### PR DESCRIPTION
Updated wildcard description to specify `*.pbd` only expands to files in the current directory.
